### PR TITLE
Remove theme color comment from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#0D9488", // Teal color from theme
+  "theme_color": "#0D9488",
   "description": "Convert PDFs and ePUBs to audiobooks with AI summaries and quizzes.",
   "icons": [
     {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#0D9488", // Teal color from theme
+  "theme_color": "#0D9488",
   "description": "Convert PDFs and ePUBs to audiobooks with AI summaries and quizzes.",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- remove a stale comment about the teal theme color from manifest files

## Testing
- `jq '.' manifest.json`
- `jq '.' public/manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_686f32cfff64832faf3b4afd1d6ce15f