### PR TITLE
Add error handling in fix-words service

### DIFF
--- a/src/services/fix-words.ts
+++ b/src/services/fix-words.ts
@@ -8,16 +8,28 @@ import { User } from "firebase/auth";
 export const fixSplitWordsWithWordList = async (user: User, text: string): Promise<string> => {
   const idToken = await user.getIdToken();
   // Call the API route
-  const response = await fetch('/api/analyze-text', {
-      method: 'POST',
-      headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${idToken}`, // Include the auth token
-      },
-      body: JSON.stringify({
-          text: text,
-      }),
-  });
-  const data = await response.json();
-  return data.text
+  try {
+    const response = await fetch('/api/analyze-text', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${idToken}`, // Include the auth token
+        },
+        body: JSON.stringify({
+            text: text,
+        }),
+    });
+
+    if (!response.ok) {
+      const errorMessage = await response.text().catch(() => response.statusText);
+      throw new Error(`Analyze-text API request failed: ${response.status} ${response.statusText} - ${errorMessage}`);
+    }
+
+    const data = await response.json();
+    return data.text;
+  } catch (error) {
+    console.error('[Word Fix] API request failed:', error);
+    // Fallback: return the original text unmodified
+    return text;
+  }
 }


### PR DESCRIPTION
## Summary
- improve API error handling in `fixSplitWordsWithWordList`

## Testing
- `npm run lint` *(fails: asks how to configure ESLint)*
- `npm run typecheck` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_686f32d22e34832f97dac34b987e5887